### PR TITLE
BUGBOT v2: concise persona-driven review analysis

### DIFF
--- a/BUGBOT.md
+++ b/BUGBOT.md
@@ -1,80 +1,24 @@
 # BUGBOT — appcharge-agent-node-public
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-## Overview
-PR reviews reveal three recurring themes: redundant HMAC signature headers being sent on outbound HTTP requests (even after the auth middleware already validates them), dead/unused code left in service and schema files, and overly complex request abstractions that make the sample code hard to follow. A single large PR (#3, 62 files) also drew direct feedback about PR size and missing unit tests.
+> Watches for auth header misuse, dead code, and over-engineered examples across this Node.js SDK sample repo.
 
-## Issue Categories
+## Security
+- **Redundant signature on outbound calls**: Remove `signature` header from gateway/reporting requests — publisher token is sufficient.
 
-### Security — Redundant Signature on Outbound Requests
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Signature header sent on outbound calls to gateways/reporting/assets when publisher token alone should be sufficient | `src/order/service.js`, `src/order/router.js`, `src/player/player.service.js` | ~3 comments |
+## Code Quality
+- **Dead code in router**: Delete unused objects and variables defined but never referenced by route handlers.
+- **Unreferenced schema definitions**: Remove or wire up any Joi schema defined in `schemas.js` that nothing imports.
+- **Stale references**: Audit service files for fields/methods that were removed elsewhere but still appear in code.
+- **Over-engineered examples**: Use plain inline objects instead of Joi validation + model classes — this is a sample repo.
+- **`module.exports` placement**: Always place `module.exports` at the bottom of the file, after all definitions.
 
-**Example review comment:**
-> "remove all signatures from requests to the gateways, publisher token should be enough"
+## Process
+- **PR size**: Keep PRs focused and small; large changesets are unreviable and block sanity checks.
+- **Missing tests**: Accompany new services with unit tests.
 
-> "you already verify the signature in auth middleware, why do you need to send it again?"
-
----
-
-### Code Quality — Dead / Unused Code
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Unused `secretsService` object defined inline in router but never used | `src/order/router.js` | ~2 comments |
-| `CreateOfferSchema` defined in schemas file but never referenced | `src/offer/schemas.js` | ~1 comment |
-| Removed features/fields still present in service code | `src/offer/service.js` | ~1 comment |
-
-**Example review comment:**
-> "it was written by a long time ago, I didn't touch this. I can remove this to make it easier to understand" (on `secretsService` in router.js)
-
-> "what CreateOfferSchema is used for?" (on an apparently unreferenced Joi schema)
-
----
-
-### Code Quality — Over-engineering / Example Complexity
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Double-layer validation + model parsing makes example code hard to read; plain objects would be clearer for a public sample repo | `src/order/router.js`, `src/offer/service.js` | ~2 comments |
-
-**Example review comment:**
-> "wouldn't it make more sense to put examples with plain objects instead of doing double validations on the input and letting them figure out the request body from the Joi validation?"
-
-> "looks complicated to understand what the object should look like, maybe we should put plain objects instead"
-
----
-
-### Code Style — Incorrect `module.exports` Placement
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| `module.exports = router` placed at the top of the file, before route handlers are registered | `src/order/router.js` | ~1 comment |
-
-**Example review comment:**
-> "move to bottom of the file" (on `module.exports` placed at line 7, before route registrations)
-
----
-
-### Process — PR Size & Missing Tests
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Single PRs with 60+ file changes are unreviable; no unit tests accompany new services | Entire repo (PR #3) | ~1 PR-level review |
-
-**Example review comment:**
-> "there are 62 files changes in this PR. i have no idea how to review it like this or how to run sanity on that amount of changes. can you please open new PRs with smaller amount of changes? and please add unit tests if needed"
-
----
-
-## Most Reviewed Areas
-| Directory | Comment Count | Main Theme |
-|-----------|--------------|------------|
-| `src/order/` | 7 | Redundant signatures, dead code, over-engineering, export placement |
-| `src/offer/` | 3 | Unused schema, complexity, dead code |
-| `src/player/` | 2 | Redundant signature forwarding |
-
-## Action Items
-- [ ] Remove `signature` header from all outbound HTTP calls to reporting, assets-upload, and gateway services — publisher token (`x-publisher-token`) is the correct auth mechanism
-- [ ] Delete unused code: `secretsService` object in `src/order/router.js` and `CreateOfferSchema` in `src/offer/schemas.js`
-- [ ] Simplify example code (router and service layers) to use plain JSON objects rather than Joi validation + model classes, making the sample repo easier to follow
-- [ ] Move all `module.exports` statements to the bottom of each file (after all route/class definitions)
-- [ ] Break large PRs into focused, smaller changesets and add unit tests for new services
+## Checklist
+- [ ] No `signature` header on outbound HTTP calls — use `x-publisher-token` only
+- [ ] No unused variables, objects, or schema definitions in router/service files
+- [ ] `module.exports` appears at the bottom of every file
+- [ ] Example payloads use plain JSON objects, not validation layers
+- [ ] PRs are scoped to a single concern with tests included

--- a/src/offer/BUGBOT.md
+++ b/src/offer/BUGBOT.md
@@ -1,40 +1,13 @@
 # BUGBOT — src/offer/
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-This directory received 3 inline review comments across `service.js` and `schemas.js`.
+> Watches for unused schema definitions, stale code, and example clarity in offer service files.
 
-## Issue Categories
+## Code Quality
+- **Unreferenced schema**: Delete `CreateOfferSchema` if nothing imports it — dead exports create confusion.
+- **File-backed example payloads**: Replace JSON file reads with inline plain objects for readability.
+- **Stale code**: Remove references to fields or methods that were already deleted elsewhere.
 
-### Code Quality — Unused Schema Definition
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| `CreateOfferSchema` is defined in `schemas.js` but reviewers could not find where it is used | `schemas.js` | ~1 comment |
-
-**Example review comment:**
-> "what CreateOfferSchema is used for?"
-
----
-
-### Code Quality — Example Complexity
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Service reads example payloads from a JSON file and applies transformations; plain inline objects would be easier to understand for consumers of the sample code | `service.js` | ~1 comment |
-
-**Example review comment:**
-> "looks complicated to understand what the object should look like, maybe we should put plain objects instead"
-
----
-
-### Code Quality — Stale / Removed Code
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Fields or methods referenced in `service.js` that were already removed elsewhere remain in the diff | `service.js` | ~1 comment |
-
-**Example review comment:**
-> "it was removed" (confirming a feature referenced in the service no longer exists)
-
-## Action Items
-- [ ] Remove or reference `CreateOfferSchema` in `schemas.js` — delete it if unused
-- [ ] Replace file-backed example payloads with inline plain objects in `service.js` to improve readability
-- [ ] Audit `service.js` for references to removed fields/methods and clean them up
+## Checklist
+- [ ] All schemas in `schemas.js` are imported and used somewhere
+- [ ] Example payloads are inline plain objects, not loaded from files
+- [ ] No references to removed fields or methods remain in `service.js`

--- a/src/order/BUGBOT.md
+++ b/src/order/BUGBOT.md
@@ -1,53 +1,17 @@
 # BUGBOT — src/order/
-> Auto-generated from PR review analysis. Do not edit manually.
-> Last updated: 2026-03-23
 
-This directory received the most review feedback in the repo (7 inline comments across `router.js` and `service.js`).
+> Watches for auth header leaks, dead code, export placement, and example complexity in order router and service.
 
-## Issue Categories
+## Security
+- **Redundant signature header**: Remove `signature` from all outbound axios calls — publisher token is the only required auth.
 
-### Security — Redundant Signature Header on Outbound Calls
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| `signature` header included in requests to the reporting API even though it was removed from that contract; publisher token is sufficient | `router.js`, `service.js` | ~2 comments |
+## Code Quality
+- **Dead inline objects**: Delete any helper object (e.g. env-var wrappers) defined at the top of the router but never used.
+- **Over-engineered route handlers**: Use plain JSON body examples — avoid Joi + model parsing layers in sample code.
+- **`module.exports` at top**: Move `module.exports = router` to the last line, after all route registrations.
 
-**Example review comment:**
-> "I believe we removed the signature when sending requests to reporting api and assets upload services"
-
-> "remove all signatures from requests to the gateways, publisher token should be enough"
-
----
-
-### Code Quality — Dead `secretsService` Object
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| A `secretsService` object that wraps env vars is defined inline at the top of the router but is never used by route handlers | `router.js` | ~2 comments |
-
-**Example review comment:**
-> "it was written a long time ago, I didn't touch this. I can remove this to make it easier to understand"
-
----
-
-### Code Quality — Over-engineering for a Sample Repo
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| Joi schema validation + `GetOrdersRequest` model parsing layers add complexity that makes the example hard to read; plain objects would communicate intent more clearly | `router.js` | ~1 comment |
-
-**Example review comment:**
-> "wouldn't it make more sense to put examples with plain objects instead of doing double validations on the input and letting them figure out the request body from the Joi validation?"
-
----
-
-### Code Style — `module.exports` at Top of File
-| Pattern | Affected Paths | Frequency |
-|---------|---------------|-----------|
-| `module.exports = router` appears at line 7, before any route handlers are defined | `router.js` | ~1 comment |
-
-**Example review comment:**
-> "move to bottom of the file"
-
-## Action Items
-- [ ] Remove the `signature` header from all axios calls in `service.js` and `router.js`
-- [ ] Delete the unused `secretsService` inline object from `router.js`
-- [ ] Move `module.exports = router` to the bottom of `router.js`
-- [ ] Simplify the route handler to use a plain JSON body example rather than Joi + model parsing
+## Checklist
+- [ ] No `signature` header in any axios request in `router.js` or `service.js`
+- [ ] No unused inline objects or variables in `router.js`
+- [ ] `module.exports` is the last statement in `router.js`
+- [ ] Route handlers use plain objects, not Joi schema + model parsing


### PR DESCRIPTION
## BUGBOT v2 — Improved Analysis Files

Replaces the previous verbose BUGBOT.md files with a concise, persona-driven format:
- Short persona block per file declaring what the BUGBOT watches
- One-line bullet rules (no PR quotes, no frequency tables, no historical examples)
- Actionable checklist at the end
- Max 60 lines (root) / 30 lines (subdirectory)

Generated by BUGBOT improve-bugbot.sh